### PR TITLE
PR for Issue #1: Splitter UI Bug

### DIFF
--- a/src/components/PanelSplitter/index.tsx
+++ b/src/components/PanelSplitter/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import type { PanelSplitterProps } from '../../types';
 
 export function PanelSplitter({
@@ -8,10 +8,17 @@ export function PanelSplitter({
   className = '',
 }: PanelSplitterProps) {
   const [isDragging, setIsDragging] = useState(false);
+  const isMountedRef = useRef(true);
+
+  // 컴포넌트 unmount 추적
+  React.useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const handleMouseDown = (e: React.MouseEvent) => {
     e.preventDefault();
-    setIsDragging(true);
     
     const container = (e.target as HTMLElement).parentElement;
     
@@ -19,6 +26,8 @@ export function PanelSplitter({
       console.warn('PanelSplitter: Container element not found');
       return;
     }
+    
+    setIsDragging(true);
     
     const containerRect = container.getBoundingClientRect();
     const containerSize = orientation === 'horizontal' 
@@ -43,7 +52,9 @@ export function PanelSplitter({
     };
 
     const handleMouseUp = () => {
-      setIsDragging(false);
+      if (isMountedRef.current) {
+        setIsDragging(false);
+      }
       
       try {
         document.removeEventListener('mousemove', handleMouseMove);

--- a/src/components/PanelSplitter/index.tsx
+++ b/src/components/PanelSplitter/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { PanelSplitterProps } from '../../types';
 
 export function PanelSplitter({
@@ -7,8 +7,12 @@ export function PanelSplitter({
   minSize = 100,
   className = '',
 }: PanelSplitterProps) {
+  const [isDragging, setIsDragging] = useState(false);
+
   const handleMouseDown = (e: React.MouseEvent) => {
     e.preventDefault();
+    setIsDragging(true);
+    
     const container = (e.target as HTMLElement).parentElement;
     
     if (!container) {
@@ -39,6 +43,8 @@ export function PanelSplitter({
     };
 
     const handleMouseUp = () => {
+      setIsDragging(false);
+      
       try {
         document.removeEventListener('mousemove', handleMouseMove);
         document.removeEventListener('mouseup', handleMouseUp);
@@ -58,6 +64,7 @@ export function PanelSplitter({
   const splitterClasses = [
     'panel-splitter',
     `panel-splitter--${orientation}`,
+    isDragging && 'panel-splitter--dragging',
     className
   ].filter(Boolean).join(' ');
 


### PR DESCRIPTION
## 🐛 Issue #01 해결 완료: Splitter UI Bug

### 📋 **문제 상황**

- 사용자가 splitter를 빠르게 드래그할 때 마우스가 splitter 영역을 벗어나면서 활성화 색상이 해제됨
- 시각적으로 드래그가 중단된 것처럼 보여 UX 저하

### 🤔 **초기 예상 원인 & 계획**

처음에는 **성능 문제**로 예상하고 복잡한 해결책을 계획했어요.

- RequestAnimationFrame을 활용한 성능 최적화
- Pointer Capture API 도입
- 새로운 dragging 상태 CSS 클래스 생성

### 🔍 **실제 코드 분석 결과**

실제로 코드를 확인해보니..

- ✅ **CSS**: `.panel-splitter--dragging` 클래스가 **이미 완벽하게 정의**되어 있음
- ❌ **JavaScript**: `isDragging` 상태 관리가 **누락**되어 해당 클래스가 적용되지 않음
- 결과적으로 `:hover`에만 의존하여 마우스가 벗어나면 스타일 해제

### ✅ **실제 해결 방법**

매우 간단한 상태 관리 추가로 해결:

```typescript
// src/components/PanelSplitter/index.tsx
const [isDragging, setIsDragging] = useState(false);

const handleMouseDown = (e: React.MouseEvent) => {
  e.preventDefault();
  setIsDragging(true); // 🔥 드래그 상태 활성화
  
  // ... 기존 로직
  
  const handleMouseUp = () => {
    setIsDragging(false); // 🔥 드래그 상태 해제
    // ... 기존 cleanup
  };
};

const splitterClasses = [
  'panel-splitter',
  `panel-splitter--${orientation}`,
  isDragging && 'panel-splitter--dragging', // 🔥 CSS 클래스 연결
  className
].filter(Boolean).join(' ');
```

### 💡 **교훈**

1. **복잡한 성능 문제로 예상** → 실제로는 **간단한 상태 관리 누락**
2. **CSS는 이미 완벽했음** → JavaScript 로직만 연결하면 됐음  
3. **문제 분석 전 기존 코드 파악 필수** → 불필요한 작업 방지

---

**Before**: 마우스가 splitter를 벗어나면 → `:hover` 해제 → 색상 사라짐 ❌  
**After**: 드래그 중에는 → `.panel-splitter--dragging` 유지 → 색상 유지 ✅
